### PR TITLE
Fix: Use current hour for surf conditions instead of midnight (fixes #5)

### DIFF
--- a/src/wavewatch/api/data_fetcher.py
+++ b/src/wavewatch/api/data_fetcher.py
@@ -636,6 +636,7 @@ class StormglassDataFetcher:
         Returns:
             Dictionary with current conditions
         """
+        current_hour_index = datetime.now().hour
         result = self.fetch_surf_data(beach_name, lat, lng, target_date)
         
         if 'error' in result:
@@ -643,8 +644,11 @@ class StormglassDataFetcher:
         
         try:
             data = result['data']
-            current_hour = data['hours'][0]  # Get current hour data
-            
+            try:
+                current_hour = data['hours'][current_hour_index]
+            except IndexError:
+                current_hour = data['hours'][0] # Default to first hour (00:00) if index is out of range
+
             # Convert units from metric to imperial
             wave_height_m = current_hour.get('waveHeight', {}).get('noaa', 'N/A')
             wave_height_ft = round(float(wave_height_m) * 3.28084, 1) if wave_height_m != 'N/A' else 'N/A'


### PR DESCRIPTION
This PR fixes issue #5 by dynamically selecting the surf data for the current hour instead of defaulting to the first index (00:00).

### Changes:
- Updated `get_current_conditions` in `data_fetcher.py`.
- Used `datetime.now().hour` to fetch the correct hourly data index.
- Added a fallback to index `0` if the current hour data is unavailable.